### PR TITLE
Increase App Engine Timeout

### DIFF
--- a/appengine_templates/app.yaml.tpl
+++ b/appengine_templates/app.yaml.tpl
@@ -11,5 +11,5 @@ env_variables:
   SERVER_PARK: _SERVER_PARK
 
 basic_scaling:
-  idle_timeout: 60s
+  idle_timeout: 10m
   max_instances: 10


### PR DESCRIPTION
To try and combat behaviour which Matthew was seeing where the application might time out waiting for an upload. The default value for this according to: https://cloud.google.com/appengine/docs/standard/nodejs/config/appref is 5 minutes.

It is likely increasing this value will increase cost slightly but our app engine costs are still comparatively tiny compared to our Windows VMs.