### PR TITLE
fix: Move the navigation out of DeleteWarning

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useEffect, useState } from "react";
-import { Route, Switch, useLocation } from "react-router-dom";
+import { Route, Switch, useHistory, useLocation } from "react-router-dom";
 import QuestionnaireList from "./components/questionnaireList";
 import UploadPage from "./components/uploadPage/uploadPage";
 import DeploymentSummary from "./components/deploymentSummary";
@@ -34,6 +34,7 @@ const divStyle = {
 
 function App(): ReactElement {
     const location = useLocation();
+    const history = useHistory();
 
     const authManager = new AuthManager();
 
@@ -76,6 +77,15 @@ function App(): ReactElement {
         return <></>;
     }
 
+    function onDeleteQuestionnaire(status: string): void {
+        history.push("/");
+        setStatus(status);
+    }
+
+    function onCancelDeleteQuestionnaire(): void {
+        history.goBack();
+    }
+
     function AppContent(): ReactElement {
         if (loaded && loggedIn) {
             return (
@@ -109,7 +119,7 @@ function App(): ReactElement {
                             <UploadPage />
                         </Route>
                         <Route path="/delete">
-                            <DeleteConfirmation setStatus={setStatus} />
+                            <DeleteConfirmation onDelete={onDeleteQuestionnaire} onCancel={onCancelDeleteQuestionnaire} />
                         </Route>
                         <Route path="/">
                             <main id="main-content" className="page__main u-mt-no">

--- a/src/components/deletePage/deleteConfirmation.tsx
+++ b/src/components/deletePage/deleteConfirmation.tsx
@@ -11,10 +11,11 @@ interface Location {
 }
 
 type Props = {
-    setStatus: (status: string) => void
+    onDelete: (status: string) => void
+    onCancel: () => void
 }
 
-function DeleteConfirmation({ setStatus }: Props): ReactElement {
+function DeleteConfirmation({ onDelete, onCancel }: Props): ReactElement {
     const location = useLocation<Location>();
     const { questionnaire, modes } = location.state || { questionnaire: "", modes: "" };
 
@@ -29,9 +30,14 @@ function DeleteConfirmation({ setStatus }: Props): ReactElement {
             <main id="main-content" className="page__main u-mt-no">
                 {
                     (
-                        questionnaire.status === "Failed" 
+                        questionnaire.status === "Failed"
                             ? <ErroneousWarning questionnaireName={questionnaire.name} />
-                            : <DeleteWarning questionnaire={questionnaire} modes={modes} setStatus={setStatus} />
+                            : <DeleteWarning
+                                questionnaire={questionnaire}
+                                modes={modes}
+                                onDelete={onDelete}
+                                onCancel={onCancel}
+                            />
                     )
                 }
             </main>

--- a/src/components/deletePage/deleteWarning.test.tsx
+++ b/src/components/deletePage/deleteWarning.test.tsx
@@ -11,7 +11,6 @@ import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
 import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
-import * as H from "history";
 import { Router } from "react-router";
 
 const mockHttp = new MockAdapter(axios);
@@ -39,7 +38,7 @@ describe("DeleteWarning", () => {
             };
 
             const view = render(
-                <DeleteWarning modes={["CAWI"]} questionnaire={questionnaire} setStatus={() => {}} />
+                <DeleteWarning modes={["CAWI"]} questionnaire={questionnaire} onDelete={() => {}} onCancel={() => {}} />
             );
 
             expect(await screen.findByText(CAWI_WARNING_MESSAGE)).toBeVisible();
@@ -54,7 +53,7 @@ describe("DeleteWarning", () => {
             };
 
             render(
-                <DeleteWarning modes={["CAWI"]} questionnaire={questionnaire} setStatus={() => {}}/>
+                <DeleteWarning modes={["CAWI"]} questionnaire={questionnaire} onDelete={() => {}} onCancel={() => {}} />
             );
             await screen.findByText(/Are you sure you want to delete/);
 
@@ -69,7 +68,7 @@ describe("DeleteWarning", () => {
             };
 
             render(
-                <DeleteWarning modes={["OTHER"]} questionnaire={questionnaire} setStatus={() => {}}/>
+                <DeleteWarning modes={["OTHER"]} questionnaire={questionnaire} onDelete={() => {}} onCancel={() => {}} />
             );
 
             expect(screen.queryByText(CAWI_WARNING_MESSAGE)).toBeNull();
@@ -87,7 +86,7 @@ describe("DeleteWarning", () => {
             mockHttp.onGet("/api/questionnaires/LMS2201_AA1/active").reply(200, true);
 
             const view = render(
-                <DeleteWarning modes={["CATI"]} questionnaire={questionnaire} setStatus={() => { }}/>
+                <DeleteWarning modes={["CATI"]} questionnaire={questionnaire} onDelete={() => { }} onCancel={() => {}}/>
             );
             expect(screen.getByText("Loading")).toBeVisible();
             expect(view).toMatchSnapshot();
@@ -103,7 +102,7 @@ describe("DeleteWarning", () => {
             };
             mockHttp.onGet("/api/questionnaires/LMS2201_AA1/active").reply(200, true);
 
-            const view = render(<DeleteWarning modes={["CATI"]} questionnaire={questionnaire} setStatus={() => {}}/>);
+            const view = render(<DeleteWarning modes={["CATI"]} questionnaire={questionnaire} onDelete={() => {}} onCancel={() => {}} />);
             expect(await screen.findByText(CATI_WARNING_MESSAGE)).toBeVisible();
             expect(view).toMatchSnapshot();
         });
@@ -116,9 +115,9 @@ describe("DeleteWarning", () => {
             };
             mockHttp.onGet("/api/questionnaires/LMS2201_AA1/active").reply(200, true);
 
-            const { rerender } = render(<DeleteWarning modes={["CATI"]} questionnaire={questionnaire} setStatus={() => {}}/>);
+            const { rerender } = render(<DeleteWarning modes={["CATI"]} questionnaire={questionnaire} onDelete={() => {}} onCancel={() => {}} />);
             expect(await screen.findByText(CATI_WARNING_MESSAGE)).toBeVisible();
-            rerender(<DeleteWarning modes={["CATI"]} questionnaire={questionnaire} setStatus={() => {}}/>);
+            rerender(<DeleteWarning modes={["CATI"]} questionnaire={questionnaire} onDelete={() => {}} onCancel={() => {}} />);
 
             expect(mockHttp.history.get.length).toBe(1);
         });
@@ -131,7 +130,7 @@ describe("DeleteWarning", () => {
             };
             mockHttp.onGet("/api/questionnaires/LMS2201_AA1/active").reply(200, true);
 
-            render(<DeleteWarning modes={["CATI"]} questionnaire={questionnaire} setStatus={() => {}}/>);
+            render(<DeleteWarning modes={["CATI"]} questionnaire={questionnaire} onDelete={() => {}} onCancel={() => {}} />);
             await screen.findByText(/Are you sure you want to delete/);
 
             expect(screen.queryByText(CATI_WARNING_MESSAGE)).toBeNull();
@@ -145,7 +144,7 @@ describe("DeleteWarning", () => {
             };
             mockHttp.onGet("/api/questionnaires/LMS2201_AA1/active").reply(200, false);
 
-            render(<DeleteWarning modes={["CATI"]} questionnaire={questionnaire} setStatus={() => {}}/>);
+            render(<DeleteWarning modes={["CATI"]} questionnaire={questionnaire} onDelete={() => {}} onCancel={() => {}} />);
             await screen.findByText(/Are you sure you want to delete/);
 
             expect(screen.queryByText(CATI_WARNING_MESSAGE)).toBeNull();
@@ -159,7 +158,7 @@ describe("DeleteWarning", () => {
             };
             mockHttp.onGet("/api/questionnaires/LMS2201_AA1/active").reply(200, true);
 
-            render(<DeleteWarning modes={["OTHER"]} questionnaire={questionnaire} setStatus={() => {}}/>);
+            render(<DeleteWarning modes={["OTHER"]} questionnaire={questionnaire} onDelete={() => {}} onCancel={() => {}} />);
             await screen.findByText(/Are you sure you want to delete/);
 
             expect(screen.queryByText(CATI_WARNING_MESSAGE)).toBeNull();
@@ -173,7 +172,7 @@ describe("DeleteWarning", () => {
             };
             mockHttp.onGet("/api/questionnaires/LMS2201_AA1/active").reply(500);
 
-            const view = render(<DeleteWarning modes={["CATI"]} questionnaire={questionnaire} setStatus={() => {}}/> );
+            const view = render(<DeleteWarning modes={["CATI"]} questionnaire={questionnaire} onDelete={() => {}} onCancel={() => {}} />);
 
             const errorMessage = "Could not get warning details, please try again";
             expect(await screen.findByText(errorMessage)).toBeVisible();
@@ -182,32 +181,25 @@ describe("DeleteWarning", () => {
     });
 
     describe("when the Cancel button is pressed", () => {
-        it("should go back on cancel", async () => {
-            const history = createMemoryHistory();
-            history.push("/one");
-            history.push("/two");
-
+        it("should call onCancel on cancel", async () => {
+            const onCancel = jest.fn();
+            const onDelete = jest.fn();
             render(
-                <Router history={history}>
-                    <DeleteWarning modes={[]} questionnaire={defaultQuestionnaire} setStatus={() => {}} />
-                </Router>
+                <DeleteWarning modes={[]} questionnaire={defaultQuestionnaire} onDelete={onDelete} onCancel={onCancel} />
             );
 
             const cancel = await screen.findByRole("button", { name: "Cancel" });
             userEvent.click(cancel);
 
-            expect(history.location.pathname).toBe("/one");
+            expect(onCancel).toHaveBeenCalledTimes(1);
+            expect(onDelete).not.toHaveBeenCalled();
         });
     });
 
     describe("when Delete button is pressed", () => {
         const questionnaire = { ...defaultQuestionnaire, name: "LMS2210_CC1" };
-        let history: H.MemoryHistory;
 
         beforeEach(() => {
-            history = createMemoryHistory();
-            history.push("/warning");
-
             mockHttp.onDelete("/api/tostartdate/LMS2210_CC1").reply(204);
             mockHttp.onDelete("/api/tmreleasedate/LMS2210_CC1").reply(204);
             mockHttp.onDelete("/api/questionnaires/LMS2210_CC1").reply(204);
@@ -215,42 +207,38 @@ describe("DeleteWarning", () => {
 
         it("should delete the TO start date, release date and questionnaire on confirm", async () => {
             render(
-                <Router history={history}>
-                    <DeleteWarning modes={[]} questionnaire={questionnaire} setStatus={() => {}}/>
-                </Router>
+                <DeleteWarning modes={[]} questionnaire={questionnaire} onDelete={() => {}} onCancel={() => {}} />
             );
 
             const confirm = await screen.findByRole("button", { name: "Delete" });
             userEvent.click(confirm);
 
-            await waitFor(() => { expect(history.location.pathname).toBe("/"); });
-            expect(mockHttp.history.delete.length).toBe(3);
+            await waitFor(() => { expect(mockHttp.history.delete.length).toBe(3); });
             expect(mockHttp.history.delete[0].url).toBe("/api/tostartdate/LMS2210_CC1");
             expect(mockHttp.history.delete[1].url).toBe("/api/tmreleasedate/LMS2210_CC1");
             expect(mockHttp.history.delete[2].url).toBe("/api/questionnaires/LMS2210_CC1");
         });
 
         it("should set the status", async () => {
-            const setStatus = jest.fn();
+            const onDelete = jest.fn();
+            const onCancel = jest.fn();
             render(
-                <Router history={history}>
-                    <DeleteWarning modes={[]} questionnaire={questionnaire} setStatus={setStatus}/>
-                </Router>
+                <DeleteWarning modes={[]} questionnaire={questionnaire} onDelete={onDelete} onCancel={onCancel} />
             );
 
             const confirm = await screen.findByRole("button", { name: "Delete" });
             userEvent.click(confirm);
-            await waitFor(() => { expect(history.location.pathname).toBe("/"); });
+            await waitFor(() => {
+                expect(onDelete).toHaveBeenCalledWith("Questionnaire: LMS2210_CC1 Successfully deleted");
+            });
 
-            expect(setStatus).toHaveBeenCalledWith("Questionnaire: LMS2210_CC1 Successfully deleted");
+            expect(onCancel).not.toHaveBeenCalled();
         });
 
         it("should display an error if deleting TO start date fails", async () => {
             mockHttp.onDelete("/api/tostartdate/LMS2210_CC1").reply(500);
             const view = render(
-                <Router history={history}>
-                    <DeleteWarning modes={[]} questionnaire={questionnaire} setStatus={() => {}}/>
-                </Router>
+                <DeleteWarning modes={[]} questionnaire={questionnaire} onDelete={() => {}} onCancel={() => {}} />
             );
 
             const confirm = await screen.findByRole("button", { name: "Delete" });
@@ -264,9 +252,7 @@ describe("DeleteWarning", () => {
         it("should display an error if deleting TO release date fails", async () => {
             mockHttp.onDelete("/api/tmreleasedate/LMS2210_CC1").reply(500);
             render(
-                <Router history={history}>
-                    <DeleteWarning modes={[]} questionnaire={questionnaire} setStatus={() => {}}/>
-                </Router>
+                <DeleteWarning modes={[]} questionnaire={questionnaire} onDelete={() => {}} onCancel={() => {}} />
             );
 
             const confirm = await screen.findByRole("button", { name: "Delete" });
@@ -279,9 +265,7 @@ describe("DeleteWarning", () => {
         it("should display an error if deleting questionnaire fails", async () => {
             mockHttp.onDelete("/api/questionnaires/LMS2210_CC1").reply(500);
             render(
-                <Router history={history}>
-                    <DeleteWarning modes={[]} questionnaire={questionnaire} setStatus={() => {}}/>
-                </Router>
+                <DeleteWarning modes={[]} questionnaire={questionnaire} onDelete={() => {}} onCancel={() => {}} />
             );
 
             const confirm = await screen.findByRole("button", { name: "Delete" });

--- a/src/components/deletePage/deleteWarning.tsx
+++ b/src/components/deletePage/deleteWarning.tsx
@@ -1,18 +1,17 @@
 import { ONSButton, ONSLoadingPanel, ONSPanel } from "blaise-design-system-react-components";
 import React, { ReactElement, useEffect, useState } from "react";
-import { useHistory } from "react-router-dom";
-import { Questionnaire, SurveyDays } from "blaise-api-node-client";
+import { Questionnaire } from "blaise-api-node-client";
 import { removeToStartDateAndDeleteQuestionnaire } from "../../client/componentProcesses";
 import { surveyIsActive } from "../../client/questionnaires";
 
 interface Props {
     questionnaire: Questionnaire
     modes: string[]
-    setStatus: (status: string) => void
+    onDelete: (message: string) => void
+    onCancel: () => void
 }
 
-function DeleteWarning({ questionnaire, modes, setStatus }: Props): ReactElement {
-    const history = useHistory();
+function DeleteWarning({ questionnaire, modes, onDelete, onCancel }: Props): ReactElement {
     const [message, setMessage] = useState<string>("");
     const [loading, setLoading] = useState<boolean>(false);
     const [loaded, setLoaded] = useState<boolean>(false);
@@ -35,10 +34,6 @@ function DeleteWarning({ questionnaire, modes, setStatus }: Props): ReactElement
         }
     }, []);
 
-    async function cancelDelete() {
-        history.goBack();
-    }
-
     function ErrorMessage(): ReactElement {
         if (message !== "") {
             return <ONSPanel status="error">
@@ -58,9 +53,8 @@ function DeleteWarning({ questionnaire, modes, setStatus }: Props): ReactElement
             return;
         }
 
-        setStatus(`Questionnaire: ${questionnaire.name} Successfully deleted`);
         setLoading(false);
-        history.push("/");
+        onDelete(`Questionnaire: ${questionnaire.name} Successfully deleted`);
     }
 
     function CatiWarning(): ReactElement {
@@ -129,7 +123,7 @@ function DeleteWarning({ questionnaire, modes, setStatus }: Props): ReactElement
                         primary={false}
                         id="cancel-delete"
                         testid="cancel-delete"
-                        onClick={() => cancelDelete()} />
+                        onClick={() => onCancel()} />
                     }
                 </form>
             </>


### PR DESCRIPTION
This is another attempt to stop the unnecessary calling of the
active endpoint. This commit does two things:

1. It moves the Navigation into App which is a better place to control
    this behaviour.
2. It calls history.push() before setStatus() - the hope is to stop and
    unnecessary re-rendering.

Refs: BLAIS5-3210
