### PR TITLE
BLAIS5-3166: Audit log Totalmobile 'release date' changes and the username in DQS

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -41,7 +41,8 @@
         }],
         "space-in-parens": ["error", "never"],
         "no-multi-spaces": "error",
-        "comma-spacing": ["error", { "before": false, "after": true }]
+        "comma-spacing": ["error", { "before": false, "after": true }],
+        "template-curly-spacing": ["error", "never"]
     },
     "overrides": [
         {

--- a/src/server/bimsApi/loggingReleaseDateManager.test.ts
+++ b/src/server/bimsApi/loggingReleaseDateManager.test.ts
@@ -112,7 +112,7 @@ describe("loggingReleaseDateManager", () => {
 
         it("logs a success message", async () => {
             await decorator.updateReleaseDate("DST211Z", "24-01-1988");
-            expect(logger.info).toHaveBeenCalledWith("Totalmobile release date updated to 24-01-1988 for DST211Z");
+            expect(logger.info).toHaveBeenCalledWith("Totalmobile release date updated to 24-01-1988 for DST211Z by rich");
             expect(logger.error).not.toHaveBeenCalled();
         });
 
@@ -130,7 +130,7 @@ describe("loggingReleaseDateManager", () => {
 
             await decorator.getReleaseDate("DST211Z");
             await decorator.updateReleaseDate("DST211Z", "2022-06-29");
-            expect(logger.info).toHaveBeenCalledWith("Totalmobile release date updated to 2022-06-29 for DST211Z. Previously 2022-12-31");
+            expect(logger.info).toHaveBeenCalledWith("Totalmobile release date updated to 2022-06-29 (previously 2022-12-31) for DST211Z by rich");
             expect(logger.error).not.toHaveBeenCalled();
         });
 
@@ -139,7 +139,7 @@ describe("loggingReleaseDateManager", () => {
 
             await decorator.getReleaseDate("LMS2111Z");
             await decorator.updateReleaseDate("DST211Z", "2022-06-29");
-            expect(logger.info).toHaveBeenCalledWith("Totalmobile release date updated to 2022-06-29 for DST211Z");
+            expect(logger.info).toHaveBeenCalledWith("Totalmobile release date updated to 2022-06-29 for DST211Z by rich");
             expect(logger.error).not.toHaveBeenCalled();
         });
     });

--- a/src/server/bimsApi/loggingReleaseDateManager.test.ts
+++ b/src/server/bimsApi/loggingReleaseDateManager.test.ts
@@ -18,7 +18,7 @@ describe("loggingReleaseDateManager", () => {
             info: jest.fn(),
             error: jest.fn(),
         };
-        decorator = new LoggingReleaseDateManager(instance, logger);
+        decorator = new LoggingReleaseDateManager(instance, logger, "rich");
     });
 
     describe("createReleaseDate", () => {
@@ -34,7 +34,7 @@ describe("loggingReleaseDateManager", () => {
 
         it("logs a success message", async () => {
             await decorator.createReleaseDate("DST211Z", "24-01-1988");
-            expect(logger.info).toHaveBeenCalledWith("Totalmobile release date set to 24-01-1988 for DST211Z");
+            expect(logger.info).toHaveBeenCalledWith("Totalmobile release date set to 24-01-1988 for DST211Z by rich");
             expect(logger.error).not.toHaveBeenCalled();
         });
 

--- a/src/server/bimsApi/loggingReleaseDateManager.test.ts
+++ b/src/server/bimsApi/loggingReleaseDateManager.test.ts
@@ -42,7 +42,7 @@ describe("loggingReleaseDateManager", () => {
             (instance.createReleaseDate as jest.Mock).mockReturnValue(Promise.reject("foo"));
 
             await expect(decorator.createReleaseDate("DST211Z", "29-06-2022")).rejects.toEqual("foo");
-            expect(logger.error).toHaveBeenCalledWith("Failed to set TM release date to 29-06-2022 for questionnaire DST211Z");
+            expect(logger.error).toHaveBeenCalledWith("Failed to set TM release date to 29-06-2022 for questionnaire DST211Z (user: rich)");
 
             expect(logger.info).not.toHaveBeenCalled();
         });
@@ -82,7 +82,7 @@ describe("loggingReleaseDateManager", () => {
             (instance.deleteReleaseDate as jest.Mock).mockReturnValue(Promise.reject("foo"));
 
             await expect(decorator.deleteReleaseDate("DST211Z")).rejects.toEqual("foo");
-            expect(logger.error).toHaveBeenCalledWith("Failed to remove TM release date for questionnaire DST211Z");
+            expect(logger.error).toHaveBeenCalledWith("Failed to remove TM release date for questionnaire DST211Z (user: rich)");
 
             expect(logger.info).not.toHaveBeenCalled();
         });
@@ -120,7 +120,7 @@ describe("loggingReleaseDateManager", () => {
             (instance.updateReleaseDate as jest.Mock).mockReturnValue(Promise.reject("foo"));
 
             await expect(decorator.updateReleaseDate("DST211Z", "2022-06-29")).rejects.toEqual("foo");
-            expect(logger.error).toHaveBeenCalledWith("Failed to set TM release date to 2022-06-29 for questionnaire DST211Z");
+            expect(logger.error).toHaveBeenCalledWith("Failed to set TM release date to 2022-06-29 for questionnaire DST211Z (user: rich)");
 
             expect(logger.info).not.toHaveBeenCalled();
         });

--- a/src/server/bimsApi/loggingReleaseDateManager.test.ts
+++ b/src/server/bimsApi/loggingReleaseDateManager.test.ts
@@ -56,7 +56,7 @@ describe("loggingReleaseDateManager", () => {
 
         it("logs a message", async () => {
             await decorator.deleteReleaseDate("DST211Z");
-            expect(logger.info).toHaveBeenCalledWith("Totalmobile release date deleted for DST211Z");
+            expect(logger.info).toHaveBeenCalledWith("Totalmobile release date deleted for DST211Z by rich");
             expect(logger.error).not.toHaveBeenCalled();
         });
 
@@ -65,7 +65,7 @@ describe("loggingReleaseDateManager", () => {
 
             await decorator.getReleaseDate("DST211Z");
             await decorator.deleteReleaseDate("DST211Z");
-            expect(logger.info).toHaveBeenCalledWith("Totalmobile release date deleted for DST211Z. Previously 2022-06-27");
+            expect(logger.info).toHaveBeenCalledWith("Totalmobile release date deleted (previously 2022-06-27) for DST211Z by rich");
             expect(logger.error).not.toHaveBeenCalled();
         });
 
@@ -74,7 +74,7 @@ describe("loggingReleaseDateManager", () => {
 
             await decorator.getReleaseDate("LMS2111Z");
             await decorator.deleteReleaseDate("DST211Z");
-            expect(logger.info).toHaveBeenCalledWith("Totalmobile release date deleted for DST211Z");
+            expect(logger.info).toHaveBeenCalledWith("Totalmobile release date deleted for DST211Z by rich");
             expect(logger.error).not.toHaveBeenCalled();
         });
 

--- a/src/server/bimsApi/loggingReleaseDateManager.ts
+++ b/src/server/bimsApi/loggingReleaseDateManager.ts
@@ -6,13 +6,13 @@ import dateFormatter from "dayjs";
 export default class LoggingReleaseDateManager implements ReleaseDateManager {
     private previousReleaseDate: Map<string, string> = new Map();
 
-    constructor(private readonly instance: ReleaseDateManager, private readonly logger: Logger) {
+    constructor(private readonly instance: ReleaseDateManager, private readonly logger: Logger, private readonly username: string) {
     }
 
     createReleaseDate(questionnaireName: string, releaseDate: string): Promise<tmReleaseDate> {
         return this.performActionAndLog(
             () => this.instance.createReleaseDate(questionnaireName, releaseDate),
-            `Totalmobile release date set to ${releaseDate} for ${questionnaireName}`,
+            `Totalmobile release date set to ${releaseDate} for ${questionnaireName} by ${this.username}`,
             `Failed to set TM release date to ${releaseDate} for questionnaire ${questionnaireName}`,
             questionnaireName
         );

--- a/src/server/bimsApi/loggingReleaseDateManager.ts
+++ b/src/server/bimsApi/loggingReleaseDateManager.ts
@@ -13,17 +13,19 @@ export default class LoggingReleaseDateManager implements ReleaseDateManager {
         return this.performActionAndLog(
             () => this.instance.createReleaseDate(questionnaireName, releaseDate),
             `Totalmobile release date set to ${releaseDate} for ${questionnaireName} by ${this.username}`,
-            `Failed to set TM release date to ${releaseDate} for questionnaire ${questionnaireName}`,
-            questionnaireName
+            `Failed to set TM release date to ${releaseDate} for questionnaire ${questionnaireName}`
         );
     }
 
     deleteReleaseDate(questionnaireName: string): Promise<void> {
+        let successMessage = `Totalmobile release date deleted for ${questionnaireName}`;
+        if(this.previousReleaseDate.has(questionnaireName)){
+            successMessage += `. Previously ${dateFormatter(this.previousReleaseDate.get(questionnaireName)).format("YYYY-MM-DD")}`;
+        }
         return this.performActionAndLog(
             () => this.instance.deleteReleaseDate(questionnaireName),
-            `Totalmobile release date deleted for ${questionnaireName}`,
-            `Failed to remove TM release date for questionnaire ${questionnaireName}`,
-            questionnaireName
+            successMessage,
+            `Failed to remove TM release date for questionnaire ${questionnaireName}`
         );
     }
 
@@ -37,25 +39,23 @@ export default class LoggingReleaseDateManager implements ReleaseDateManager {
     }
 
     updateReleaseDate(questionnaireName: string, releaseDate: string): Promise<tmReleaseDate> {
+        let successMessage = `Totalmobile release date updated to ${releaseDate} for ${questionnaireName} by ${this.username}`;
+        if(this.previousReleaseDate.has(questionnaireName)){
+            successMessage = `Totalmobile release date updated to ${releaseDate} (previously ${dateFormatter(this.previousReleaseDate.get(questionnaireName)).format("YYYY-MM-DD")}) for ${questionnaireName} by ${this.username}`;
+        }
+
         return this.performActionAndLog(
             () => this.instance.updateReleaseDate(questionnaireName, releaseDate),
-            `Totalmobile release date updated to ${releaseDate} for ${questionnaireName}`,
-            `Failed to set TM release date to ${releaseDate} for questionnaire ${questionnaireName}`,
-            questionnaireName
+            successMessage,
+            `Failed to set TM release date to ${releaseDate} for questionnaire ${questionnaireName}`
         );
     }
 
-    private async performActionAndLog <Result> (action: () => Promise<Result>, successMessage: string, errorMessage: string, questionnaireName: string): Promise<Result> {
+    private async performActionAndLog <Result> (action: () => Promise<Result>, successMessage: string, errorMessage: string): Promise<Result> {
         try {
             const result = await action();
-            let message = successMessage;
-
-            if(this.previousReleaseDate.has(questionnaireName)){
-                message += `. Previously ${dateFormatter(this.previousReleaseDate.get(questionnaireName)).format("YYYY-MM-DD")}`;
-            }
-            this.logger.info(message);
+            this.logger.info(successMessage);
             return result;
-
         } catch (error) {
             this.logger.error(errorMessage);
             throw error;

--- a/src/server/bimsApi/loggingReleaseDateManager.ts
+++ b/src/server/bimsApi/loggingReleaseDateManager.ts
@@ -13,19 +13,17 @@ export default class LoggingReleaseDateManager implements ReleaseDateManager {
         return this.performActionAndLog(
             () => this.instance.createReleaseDate(questionnaireName, releaseDate),
             `Totalmobile release date set to ${releaseDate} for ${questionnaireName} by ${this.username}`,
-            `Failed to set TM release date to ${releaseDate} for questionnaire ${questionnaireName} (user: ${this.username})`
+            `Failed to set TM release date to ${releaseDate} for questionnaire ${questionnaireName} (user: ${this.username})`,
+            questionnaireName
         );
     }
 
     deleteReleaseDate(questionnaireName: string): Promise<void> {
-        let successMessage = `Totalmobile release date deleted for ${questionnaireName} by ${this.username}`;
-        if(this.previousReleaseDate.has(questionnaireName)) {
-            successMessage = `Totalmobile release date deleted (previously ${dateFormatter(this.previousReleaseDate.get(questionnaireName)).format("YYYY-MM-DD")}) for ${questionnaireName} by ${this.username}`;
-        }
         return this.performActionAndLog(
             () => this.instance.deleteReleaseDate(questionnaireName),
-            successMessage,
-            `Failed to remove TM release date for questionnaire ${questionnaireName} (user: ${this.username})`
+            `Totalmobile release date deleted{previous} for ${questionnaireName} by ${this.username}`,
+            `Failed to remove TM release date for questionnaire ${questionnaireName} (user: ${this.username})`,
+            questionnaireName
         );
     }
 
@@ -39,25 +37,30 @@ export default class LoggingReleaseDateManager implements ReleaseDateManager {
     }
 
     updateReleaseDate(questionnaireName: string, releaseDate: string): Promise<tmReleaseDate> {
-        let successMessage = `Totalmobile release date updated to ${releaseDate} for ${questionnaireName} by ${this.username}`;
-        if(this.previousReleaseDate.has(questionnaireName)){
-            successMessage = `Totalmobile release date updated to ${releaseDate} (previously ${dateFormatter(this.previousReleaseDate.get(questionnaireName)).format("YYYY-MM-DD")}) for ${questionnaireName} by ${this.username}`;
-        }
-
         return this.performActionAndLog(
             () => this.instance.updateReleaseDate(questionnaireName, releaseDate),
-            successMessage,
-            `Failed to set TM release date to ${releaseDate} for questionnaire ${questionnaireName} (user: ${this.username})`
+            `Totalmobile release date updated to ${releaseDate}{previous} for ${questionnaireName} by ${this.username}`,
+            `Failed to set TM release date to ${releaseDate} for questionnaire ${questionnaireName} (user: ${this.username})`,
+            questionnaireName
         );
     }
 
-    private async performActionAndLog <Result> (action: () => Promise<Result>, successMessage: string, errorMessage: string): Promise<Result> {
+    private async performActionAndLog <Result>(action: () => Promise<Result>, successMessage: string, errorMessage: string, questionnaireName: string): Promise<Result> {
+        const prepareMessage = (successMessage: string) => {
+            let previous = "";
+            if (this.previousReleaseDate.has(questionnaireName)) {
+                previous = ` (previously ${dateFormatter(this.previousReleaseDate.get(questionnaireName)).format("YYYY-MM-DD")})`;
+            }
+            return successMessage
+                .replace("{previous}", previous);
+        };
+
         try {
             const result = await action();
-            this.logger.info(successMessage);
+            this.logger.info(prepareMessage(successMessage));
             return result;
         } catch (error) {
-            this.logger.error(errorMessage);
+            this.logger.error(prepareMessage(errorMessage));
             throw error;
         }
     }

--- a/src/server/bimsApi/loggingReleaseDateManager.ts
+++ b/src/server/bimsApi/loggingReleaseDateManager.ts
@@ -18,9 +18,9 @@ export default class LoggingReleaseDateManager implements ReleaseDateManager {
     }
 
     deleteReleaseDate(questionnaireName: string): Promise<void> {
-        let successMessage = `Totalmobile release date deleted for ${questionnaireName}`;
-        if(this.previousReleaseDate.has(questionnaireName)){
-            successMessage += `. Previously ${dateFormatter(this.previousReleaseDate.get(questionnaireName)).format("YYYY-MM-DD")}`;
+        let successMessage = `Totalmobile release date deleted for ${questionnaireName} by ${this.username}`;
+        if(this.previousReleaseDate.has(questionnaireName)) {
+            successMessage = `Totalmobile release date deleted (previously ${dateFormatter(this.previousReleaseDate.get(questionnaireName)).format("YYYY-MM-DD")}) for ${questionnaireName} by ${this.username}`;
         }
         return this.performActionAndLog(
             () => this.instance.deleteReleaseDate(questionnaireName),

--- a/src/server/bimsApi/loggingReleaseDateManager.ts
+++ b/src/server/bimsApi/loggingReleaseDateManager.ts
@@ -13,7 +13,7 @@ export default class LoggingReleaseDateManager implements ReleaseDateManager {
         return this.performActionAndLog(
             () => this.instance.createReleaseDate(questionnaireName, releaseDate),
             `Totalmobile release date set to ${releaseDate} for ${questionnaireName} by ${this.username}`,
-            `Failed to set TM release date to ${releaseDate} for questionnaire ${questionnaireName}`
+            `Failed to set TM release date to ${releaseDate} for questionnaire ${questionnaireName} (user: ${this.username})`
         );
     }
 
@@ -25,7 +25,7 @@ export default class LoggingReleaseDateManager implements ReleaseDateManager {
         return this.performActionAndLog(
             () => this.instance.deleteReleaseDate(questionnaireName),
             successMessage,
-            `Failed to remove TM release date for questionnaire ${questionnaireName}`
+            `Failed to remove TM release date for questionnaire ${questionnaireName} (user: ${this.username})`
         );
     }
 
@@ -47,7 +47,7 @@ export default class LoggingReleaseDateManager implements ReleaseDateManager {
         return this.performActionAndLog(
             () => this.instance.updateReleaseDate(questionnaireName, releaseDate),
             successMessage,
-            `Failed to set TM release date to ${releaseDate} for questionnaire ${questionnaireName}`
+            `Failed to set TM release date to ${releaseDate} for questionnaire ${questionnaireName} (user: ${this.username})`
         );
     }
 

--- a/src/server/handlers/bimsHandler.test.ts
+++ b/src/server/handlers/bimsHandler.test.ts
@@ -317,6 +317,15 @@ describe("Deleting Totalmobile release date to BIMS service", () => {
         expect(response.status).toEqual(204);
     });
 
+    it("should log a message the TM release date has been deleted", async () => {
+        mock.onGet(`${config.BimsApiUrl}/tmreleasedate/LMS2004A`).reply(200, { "tmreleasedate": "2022-12-31" }, jsonHeaders);
+        mock.onDelete(`${config.BimsApiUrl}/tmreleasedate/LMS2004A`).reply(204, {}, jsonHeaders);
+
+        await request.delete("/api/tmreleasedate/LMS2004A");
+
+        expect(logInfo).toHaveBeenCalledWith("AUDIT_LOG: Totalmobile release date deleted (previously 2022-12-31) for LMS2004A by rich");
+    });
+
     it("should return a 204 status when the TM release date doesn't exits", async () => {
         mock.onGet(`${config.BimsApiUrl}/tmreleasedate/LMS2004A`).reply(404, {}, jsonHeaders);
 

--- a/src/server/handlers/bimsHandler.test.ts
+++ b/src/server/handlers/bimsHandler.test.ts
@@ -15,7 +15,7 @@ jest.mock("blaise-login-react-server", () => {
     };
 });
 Auth.prototype.ValidateToken = jest.fn().mockReturnValue(true);
-Auth.prototype.GetUser = jest.fn().mockImplementation((token) => token === "example-token" ? {name: "rich"} : {});
+Auth.prototype.GetUser = jest.fn().mockImplementation((token) => token === "example-token" ? { name: "rich" } : {});
 Auth.prototype.GetToken = jest.fn().mockReturnValue("example-token");
 
 jest.mock("blaise-iap-node-provider");
@@ -241,7 +241,7 @@ describe("Sending Totalmobile release date to BIMS service", () => {
 
             it("should log a message when a release date is provided", async () => {
                 await request.post("/api/tmreleasedate/LMS2004A").send({ "tmreleasedate": "2022-12-31" });
-                expect(logInfo).toHaveBeenCalledWith("AUDIT_LOG: Totalmobile release date updated to 2022-12-31 for LMS2004A. Previously 2022-06-27");
+                expect(logInfo).toHaveBeenCalledWith("AUDIT_LOG: Totalmobile release date updated to 2022-12-31 (previously 2022-06-27) for LMS2004A by rich");
             });
         });
 

--- a/src/server/handlers/bimsHandler.test.ts
+++ b/src/server/handlers/bimsHandler.test.ts
@@ -11,10 +11,12 @@ import pino from "pino";
 jest.mock("blaise-login-react-server", () => {
     const loginReact = jest.requireActual("blaise-login-react-server");
     return {
-        ...loginReact
+        ...loginReact,
     };
 });
 Auth.prototype.ValidateToken = jest.fn().mockReturnValue(true);
+Auth.prototype.GetUser = jest.fn().mockImplementation((token) => token === "example-token" ? {name: "rich"} : {});
+Auth.prototype.GetToken = jest.fn().mockReturnValue("example-token");
 
 jest.mock("blaise-iap-node-provider");
 
@@ -191,7 +193,7 @@ describe("Sending Totalmobile release date to BIMS service", () => {
             it("should log a message when a release date is provided", async () => {
                 await request.post("/api/tmreleasedate/LMS2004A").send({ "tmreleasedate": "2022-12-31" });
 
-                expect(logInfo).toHaveBeenCalledWith("AUDIT_LOG: Totalmobile release date set to 2022-12-31 for LMS2004A");
+                expect(logInfo).toHaveBeenCalledWith("AUDIT_LOG: Totalmobile release date set to 2022-12-31 for LMS2004A by rich");
             });
         });
 

--- a/src/server/handlers/bimsHandler.test.ts
+++ b/src/server/handlers/bimsHandler.test.ts
@@ -264,7 +264,7 @@ describe("Sending Totalmobile release date to BIMS service", () => {
 
             it("should log a message when a release date is not provided", async () => {
                 await request.post("/api/tmreleasedate/LMS2004A").send({ "tmreleasedate": "" });
-                expect(logInfo).toHaveBeenCalledWith("AUDIT_LOG: Totalmobile release date deleted for LMS2004A. Previously 2022-06-27");
+                expect(logInfo).toHaveBeenCalledWith("AUDIT_LOG: Totalmobile release date deleted (previously 2022-06-27) for LMS2004A by rich");
             });
         });
     });

--- a/src/server/handlers/bimsHandler.ts
+++ b/src/server/handlers/bimsHandler.ts
@@ -159,7 +159,8 @@ export class BimsHandler {
 
             await this.bimsApiClient.deleteReleaseDate(questionnaireName);
 
-            this.auditLogger.info(req.log, `Totalmobile release date removed for ${questionnaireName}. Previously ${previousReleaseDate}`);
+            const username = this.auth.GetUser(this.auth.GetToken(req)).name;
+            this.auditLogger.info(req.log, `Totalmobile release date deleted (previously ${previousReleaseDate}) for ${questionnaireName} by ${username}`);
             return res.status(204).json();
         } catch (error: unknown) {
             console.error(error);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -26,7 +26,6 @@ if (process.env.NODE_ENV === "production") {
     });
 } else {
     dotenv.config();
-    process.env.GOOGLE_APPLICATION_CREDENTIALS = path.join(__dirname, "../keys.json");
 }
 
 export function newServer(config: Config, logger: HttpLogger = createLogger()): Express {


### PR DESCRIPTION
Refs: BLAIS5-3166
Co-authored-by: elthorne <elthorne@users.noreply.github.com>
